### PR TITLE
Add typescript types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+node_modules
+.DS_Store
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "highlightjs-abc",
+  "version": "1.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "highlightjs-abc",
+      "version": "1.1.0",
+      "license": "MIT",
+      "peerDependencies": {
+        "highlight.js": "^11.11.1"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,8 +14,12 @@
   "author": "NriotHrreion",
   "type": "module",
   "main": "src/languages/abc.js",
+  "types": "types/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": ["hljs", "highlightjs", "abc-notation", "music"]
+  "keywords": ["hljs", "highlightjs", "abc-notation", "music"],
+  "peerDependencies": {
+    "highlight.js": "^11.11.1"
+  }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,5 @@
+import type {HLJSApi} from "highlight.js";
+
+declare module 'highlightjs-abc' {
+	export default function (hljs: HLJSApi)
+}


### PR DESCRIPTION
This adds typescript types so that the following line doesn't throw an error in a typescript app:
```
import highlightAbc from "highlightjs-abc"
```

I added highlight.js as a peer dependency to get the types from it. I'm not positive that is the right way to do that but it seems to work. I doubt this library would be used in a circumstance where highlightjs isn't present.
